### PR TITLE
Torch compile possible workaround

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -6,6 +6,15 @@ import comfy.ops
 import comfy.model_management
 from .dequant import dequantize_tensor, is_quantized
 
+# to avoid breaking really old pytorch versions
+if hasattr(torch, "compiler") and hasattr(torch.compiler, "disable"):
+    torch_compiler_disable = torch.compiler.disable
+else:
+    def torch_compiler_disable(*args, **kwargs):
+        def noop(x):
+            return x
+        return noop
+
 class GGMLTensor(torch.Tensor):
     """
     Main tensor-like class for storing quantized weights
@@ -152,6 +161,7 @@ class GGMLLayer(torch.nn.Module):
                 weight = function(patch_list, weight, key, patch_dtype)
         return weight
 
+    @torch_compiler_disable()
     def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None):
         if input is not None:
             if dtype is None:


### PR DESCRIPTION
Seems to help on torch 2.6.0 with triton 3.2.0, less so on old versions. Includes workaround for 2.0.X and other really old versions #118

## Summary by Sourcery

Enhancements:
- Adds a decorator to disable the torch compiler for specific functions, which can improve performance on some PyTorch versions.